### PR TITLE
Allow empty param in the connection string

### DIFF
--- a/pkg/server/database/database.go
+++ b/pkg/server/database/database.go
@@ -42,13 +42,13 @@ func getPGConnectionString() string {
 	}
 
 	return fmt.Sprintf(
-		"host=%s port=%s dbname=%s user=%s password=%s sslmode=%s",
+		"sslmode=%s host=%s port=%s dbname=%s user=%s password=%s",
+		sslmode,
 		os.Getenv("DBHost"),
 		os.Getenv("DBPort"),
 		os.Getenv("DBName"),
 		os.Getenv("DBUser"),
 		os.Getenv("DBPassword"),
-		sslmode,
 	)
 }
 


### PR DESCRIPTION
Fix an issue where empty password parameter causes the connection string to be invalid. The fix is to place the password field at the very last.