### PR TITLE
Fix conflict report format

### DIFF
--- a/pkg/assert/assert.go
+++ b/pkg/assert/assert.go
@@ -30,7 +30,20 @@ import (
 	"github.com/pkg/errors"
 )
 
-func checkEqual(a interface{}, b interface{}, message string) (bool, string) {
+func getErrorMessage(m string, a, b interface{}) string {
+	return fmt.Sprintf(`%s.
+Actual:
+========================
+%+v
+========================
+
+Expected:
+========================
+%+v
+========================`, m, a, b)
+}
+
+func checkEqual(a, b interface{}, message string) (bool, string) {
 	if a == b {
 		return true, ""
 	}
@@ -41,13 +54,13 @@ func checkEqual(a interface{}, b interface{}, message string) (bool, string) {
 	} else {
 		m = message
 	}
-	errorMessage := fmt.Sprintf("%s.\n==== Actual ====\n%+v\n=============\n==== Expected ====\n%+v\n=================", m, a, b)
+	errorMessage := getErrorMessage(m, a, b)
 
 	return false, errorMessage
 }
 
 // Equal errors a test if the actual does not match the expected
-func Equal(t *testing.T, a interface{}, b interface{}, message string) {
+func Equal(t *testing.T, a, b interface{}, message string) {
 	ok, m := checkEqual(a, b, message)
 	if !ok {
 		t.Error(m)
@@ -55,7 +68,7 @@ func Equal(t *testing.T, a interface{}, b interface{}, message string) {
 }
 
 // Equalf fails a test if the actual does not match the expected
-func Equalf(t *testing.T, a interface{}, b interface{}, message string) {
+func Equalf(t *testing.T, a, b interface{}, message string) {
 	ok, m := checkEqual(a, b, message)
 	if !ok {
 		t.Fatal(m)
@@ -63,18 +76,15 @@ func Equalf(t *testing.T, a interface{}, b interface{}, message string) {
 }
 
 // NotEqual fails a test if the actual matches the expected
-func NotEqual(t *testing.T, a interface{}, b interface{}, message string) {
-	if a != b {
-		return
+func NotEqual(t *testing.T, a, b interface{}, message string) {
+	ok, m := checkEqual(a, b, message)
+	if ok {
+		t.Error(m)
 	}
-	if len(message) == 0 {
-		message = fmt.Sprintf("%v == %v", a, b)
-	}
-	t.Errorf("%s. Actual: %+v. Expected: %+v.", message, a, b)
 }
 
 // DeepEqual fails a test if the actual does not deeply equal the expected
-func DeepEqual(t *testing.T, a interface{}, b interface{}, message string) {
+func DeepEqual(t *testing.T, a, b interface{}, message string) {
 	if reflect.DeepEqual(a, b) {
 		return
 	}
@@ -82,7 +92,9 @@ func DeepEqual(t *testing.T, a interface{}, b interface{}, message string) {
 	if len(message) == 0 {
 		message = fmt.Sprintf("%v != %v", a, b)
 	}
-	t.Errorf("%s.\nActual:   %+v.\nExpected: %+v.", message, a, b)
+
+	errorMessage := getErrorMessage(message, a, b)
+	t.Error(errorMessage)
 }
 
 // EqualJSON asserts that two JSON strings are equal

--- a/pkg/cli/cmd/edit/edit.go
+++ b/pkg/cli/cmd/edit/edit.go
@@ -95,9 +95,7 @@ func changeContent(ctx context.DnoteCtx, tx *database.DB, note database.Note, co
 		return errors.New("Nothing changed")
 	}
 
-	sanitized := ui.SanitizeContent(content)
-
-	if err := database.UpdateNoteContent(tx, ctx.Clock, note.RowID, sanitized); err != nil {
+	if err := database.UpdateNoteContent(tx, ctx.Clock, note.RowID, content); err != nil {
 		return errors.Wrap(err, "updating the note")
 	}
 

--- a/pkg/cli/cmd/ls/ls.go
+++ b/pkg/cli/cmd/ls/ls.go
@@ -114,15 +114,16 @@ func getNewlineIdx(str string) int {
 // formatBody returns an excerpt of the given raw note content and a boolean
 // indicating if the returned string has been excertped
 func formatBody(noteBody string) (string, bool) {
-	newlineIdx := getNewlineIdx(noteBody)
+	trimmed := strings.TrimRight(noteBody, "\r\n")
+	newlineIdx := getNewlineIdx(trimmed)
 
 	if newlineIdx > -1 {
-		ret := strings.Trim(noteBody[0:newlineIdx], " ")
+		ret := strings.Trim(trimmed[0:newlineIdx], " ")
 
 		return ret, true
 	}
 
-	return strings.Trim(noteBody, " "), false
+	return strings.Trim(trimmed, " "), false
 }
 
 func printBookLine(info bookInfo, nameOnly bool) {

--- a/pkg/cli/cmd/sync/merge_test.go
+++ b/pkg/cli/cmd/sync/merge_test.go
@@ -42,21 +42,14 @@ func TestReportConflict(t *testing.T) {
 			expected: "",
 		},
 		{
-			local:  "foo\nbar",
-			server: "foo\nbar",
-			expected: `foo
-bar
-`,
+			local:    "foo",
+			server:   "foo",
+			expected: "foo",
 		},
 		{
-			local:  "foo",
-			server: "bar",
-			expected: `<<<<<<< Local
-foo
-=======
-bar
->>>>>>> Server
-`,
+			local:    "foo\nbar",
+			server:   "foo\nbar",
+			expected: "foo\nbar",
 		},
 		{
 			local:  "foo-local",
@@ -65,6 +58,16 @@ bar
 foo-local
 =======
 foo-server
+>>>>>>> Server
+`,
+		},
+		{
+			local:  "foo\n",
+			server: "bar\n",
+			expected: `<<<<<<< Local
+foo
+=======
+bar
 >>>>>>> Server
 `,
 		},
@@ -90,8 +93,8 @@ foo
 `,
 		},
 		{
-			local:  "foo\n\nquz\nbaz",
-			server: "foo\n\nbar\nbaz",
+			local:  "foo\n\nquz\nbaz\n",
+			server: "foo\n\nbar\nbaz\n",
 			expected: `foo
 
 <<<<<<< Local

--- a/pkg/cli/cmd/sync/merge_test.go
+++ b/pkg/cli/cmd/sync/merge_test.go
@@ -125,6 +125,20 @@ fuuz
 >>>>>>> Server
 `,
 		},
+		{
+			local:  "foo\nquz\nbaz\nbar\n",
+			server: "foo\nquzz\nbazz\nbar\n",
+			expected: `foo
+<<<<<<< Local
+quz
+baz
+=======
+quzz
+bazz
+>>>>>>> Server
+bar
+`,
+		},
 	}
 
 	for idx, tc := range testCases {

--- a/pkg/cli/cmd/sync/sync.go
+++ b/pkg/cli/cmd/sync/sync.go
@@ -291,7 +291,7 @@ func mergeNote(tx *database.DB, serverNote client.SyncFragNote, localNote databa
 		return nil
 	}
 
-	// if the local copy is deleted, and the it was edited on the server, override with server values and mark it not dirty.
+	// if the local copy is deleted, and it was edited on the server, override with server values and mark it not dirty.
 	if localNote.Deleted {
 		if _, err := tx.Exec("UPDATE notes SET usn = ?, book_uuid = ?, body = ?, edited_on = ?, deleted = ?, public = ?, dirty = ? WHERE uuid = ?",
 			serverNote.USN, serverNote.BookUUID, serverNote.Body, serverNote.EditedOn, serverNote.Deleted, serverNote.Public, false, serverNote.UUID); err != nil {

--- a/pkg/cli/ui/editor.go
+++ b/pkg/cli/ui/editor.go
@@ -78,20 +78,6 @@ func getEditorCommand() string {
 	return ret
 }
 
-// SanitizeContent sanitizes note content
-func SanitizeContent(s string) string {
-	var ret string
-
-	ret = strings.Trim(s, " ")
-
-	// Remove newline at the end of the file because POSIX defines a line as
-	// characters followed by a newline
-	ret = strings.TrimSuffix(ret, "\n")
-	ret = strings.TrimSuffix(ret, "\r\n")
-
-	return ret
-}
-
 func newEditorCmd(ctx context.DnoteCtx, fpath string) (*exec.Cmd, error) {
 	args := strings.Fields(ctx.Editor)
 	args = append(args, fpath)
@@ -147,9 +133,7 @@ func GetEditorInput(ctx context.DnoteCtx, fpath string, content *string) error {
 	}
 
 	raw := string(b)
-	c := SanitizeContent(raw)
-
-	*content = c
+	*content = raw
 
 	return nil
 }

--- a/pkg/server/api/handlers/limit.go
+++ b/pkg/server/api/handlers/limit.go
@@ -43,7 +43,7 @@ func init() {
 // addVisitor adds a new visitor to the map and returns a limiter for the visitor
 func addVisitor(identifier string) *rate.Limiter {
 	// initialize a token bucket
-	limiter := rate.NewLimiter(rate.Every(1*time.Second), 15)
+	limiter := rate.NewLimiter(rate.Every(1*time.Second), 60)
 
 	mtx.Lock()
 	visitors[identifier] = &visitor{


### PR DESCRIPTION
* Stop appending a linebreak when resolving conflicts.
* Stop trimming a linebreak suffix from editor input. Instead, respect the input as is.