### PR TITLE
Simplify remove book command

### DIFF
--- a/pkg/cli/COMMANDS.md
+++ b/pkg/cli/COMMANDS.md
@@ -45,7 +45,7 @@ dnote view 12
 
 _alias: e_
 
-Edit a note.
+Edit a note or a book.
 
 ```bash
 # Launch a text editor to edit a note with the given id.
@@ -53,20 +53,26 @@ dnote edit 12
 
 # Edit a note with the given id in the specified book with a content.
 dnote edit 12 -c "New Content"
+
+# Launch a text editor to edit a book name.
+dnote edit js
+
+# Edit a book name by using a flag.
+dnote edit js -n "javascript"
 ```
 
 ## dnote remove
 
-_alias: d_
+_alias: rm, d_
 
 Remove either a note or a book.
 
 ```bash
-# Remove the note with an id in the specified book.
+# Remove a note with an id.
 dnote remove 1
 
-# Remove the book with the `book name`.
-dnote remove -b JS
+# Remove a book with the `book name`.
+dnote remove js
 ```
 
 ## dnote find

--- a/pkg/cli/cmd/cat/cat.go
+++ b/pkg/cli/cmd/cat/cat.go
@@ -35,7 +35,7 @@ var example = `
  dnote cat javascript 2
  `
 
-var deprecationWarning = `and "view" will replace it in v0.5.0.
+var deprecationWarning = `and "view" will replace it in the future version.
 
  Run "dnote view --help" for more information.
 `

--- a/pkg/cli/cmd/edit/edit.go
+++ b/pkg/cli/cmd/edit/edit.go
@@ -51,7 +51,7 @@ var example = `
 // NewCmd returns a new edit command
 func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "edit",
+		Use:     "edit <note id|book name>",
 		Short:   "Edit a note or a book",
 		Aliases: []string{"e"},
 		Example: example,

--- a/pkg/cli/cmd/ls/ls.go
+++ b/pkg/cli/cmd/ls/ls.go
@@ -38,7 +38,7 @@ var example = `
  dnote ls javascript
  `
 
-var deprecationWarning = `and "view" will replace it in v1.0.0.
+var deprecationWarning = `and "view" will replace it in the future version.
 
 Run "dnote view --help" for more information.
 `

--- a/pkg/cli/main_test.go
+++ b/pkg/cli/main_test.go
@@ -320,191 +320,176 @@ func TestEditBook(t *testing.T) {
 }
 
 func TestRemoveNote(t *testing.T) {
-	t.Run("no flag", func(t *testing.T) {
-		// Setup
-		db := database.InitTestDB(t, fmt.Sprintf("%s/%s", opts.DnoteDir, consts.DnoteDBFileName), nil)
-		testutils.Setup2(t, db)
+	testCases := []struct {
+		yesFlag bool
+	}{
+		{
+			yesFlag: false,
+		},
+		{
+			yesFlag: true,
+		},
+	}
 
-		// Execute
-		testutils.WaitDnoteCmd(t, opts, testutils.UserConfirm, binaryName, "remove", "1")
-		defer testutils.RemoveDir(t, opts.HomeDir)
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("--yes=%t", tc.yesFlag), func(t *testing.T) {
+			// Setup
+			db := database.InitTestDB(t, fmt.Sprintf("%s/%s", opts.DnoteDir, consts.DnoteDBFileName), nil)
+			testutils.Setup2(t, db)
 
-		// Test
-		var noteCount, bookCount, jsNoteCount, linuxNoteCount int
-		database.MustScan(t, "counting books", db.QueryRow("SELECT count(*) FROM books"), &bookCount)
-		database.MustScan(t, "counting notes", db.QueryRow("SELECT count(*) FROM notes"), &noteCount)
-		database.MustScan(t, "counting js notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "js-book-uuid"), &jsNoteCount)
-		database.MustScan(t, "counting linux notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "linux-book-uuid"), &linuxNoteCount)
+			// Execute
+			if tc.yesFlag {
+				testutils.RunDnoteCmd(t, opts, binaryName, "remove", "-y", "1")
+			} else {
+				testutils.WaitDnoteCmd(t, opts, testutils.UserConfirm, binaryName, "remove", "1")
+			}
+			defer testutils.RemoveDir(t, opts.HomeDir)
 
-		assert.Equalf(t, bookCount, 2, "book count mismatch")
-		assert.Equalf(t, noteCount, 3, "note count mismatch")
-		assert.Equal(t, jsNoteCount, 2, "js book should have 2 notes")
-		assert.Equal(t, linuxNoteCount, 1, "linux book book should have 1 note")
+			// Test
+			var noteCount, bookCount, jsNoteCount, linuxNoteCount int
+			database.MustScan(t, "counting books", db.QueryRow("SELECT count(*) FROM books"), &bookCount)
+			database.MustScan(t, "counting notes", db.QueryRow("SELECT count(*) FROM notes"), &noteCount)
+			database.MustScan(t, "counting js notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "js-book-uuid"), &jsNoteCount)
+			database.MustScan(t, "counting linux notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "linux-book-uuid"), &linuxNoteCount)
 
-		var b1, b2 database.Book
-		var n1, n2, n3 database.Note
-		database.MustScan(t, "getting b1",
-			db.QueryRow("SELECT label, deleted, usn FROM books WHERE uuid = ?", "js-book-uuid"),
-			&b1.Label, &b1.Deleted, &b1.USN)
-		database.MustScan(t, "getting b2",
-			db.QueryRow("SELECT label, deleted, usn FROM books WHERE uuid = ?", "linux-book-uuid"),
-			&b2.Label, &b2.Deleted, &b2.USN)
-		database.MustScan(t, "getting n1",
-			db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f"),
-			&n1.UUID, &n1.Body, &n1.AddedOn, &n1.Deleted, &n1.Dirty, &n1.USN)
-		database.MustScan(t, "getting n2",
-			db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "43827b9a-c2b0-4c06-a290-97991c896653"),
-			&n2.UUID, &n2.Body, &n2.AddedOn, &n2.Deleted, &n2.Dirty, &n2.USN)
-		database.MustScan(t, "getting n3",
-			db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "linux-book-uuid", "3e065d55-6d47-42f2-a6bf-f5844130b2d2"),
-			&n3.UUID, &n3.Body, &n3.AddedOn, &n3.Deleted, &n3.Dirty, &n3.USN)
+			assert.Equalf(t, bookCount, 2, "book count mismatch")
+			assert.Equalf(t, noteCount, 3, "note count mismatch")
+			assert.Equal(t, jsNoteCount, 2, "js book should have 2 notes")
+			assert.Equal(t, linuxNoteCount, 1, "linux book book should have 1 note")
 
-		assert.Equal(t, b1.Label, "js", "b1 label mismatch")
-		assert.Equal(t, b1.Deleted, false, "b1 deleted mismatch")
-		assert.Equal(t, b1.Dirty, false, "b1 Dirty mismatch")
-		assert.Equal(t, b1.USN, 111, "b1 usn mismatch")
+			var b1, b2 database.Book
+			var n1, n2, n3 database.Note
+			database.MustScan(t, "getting b1",
+				db.QueryRow("SELECT label, deleted, usn FROM books WHERE uuid = ?", "js-book-uuid"),
+				&b1.Label, &b1.Deleted, &b1.USN)
+			database.MustScan(t, "getting b2",
+				db.QueryRow("SELECT label, deleted, usn FROM books WHERE uuid = ?", "linux-book-uuid"),
+				&b2.Label, &b2.Deleted, &b2.USN)
+			database.MustScan(t, "getting n1",
+				db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f"),
+				&n1.UUID, &n1.Body, &n1.AddedOn, &n1.Deleted, &n1.Dirty, &n1.USN)
+			database.MustScan(t, "getting n2",
+				db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "43827b9a-c2b0-4c06-a290-97991c896653"),
+				&n2.UUID, &n2.Body, &n2.AddedOn, &n2.Deleted, &n2.Dirty, &n2.USN)
+			database.MustScan(t, "getting n3",
+				db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "linux-book-uuid", "3e065d55-6d47-42f2-a6bf-f5844130b2d2"),
+				&n3.UUID, &n3.Body, &n3.AddedOn, &n3.Deleted, &n3.Dirty, &n3.USN)
 
-		assert.Equal(t, b2.Label, "linux", "b2 label mismatch")
-		assert.Equal(t, b2.Deleted, false, "b2 deleted mismatch")
-		assert.Equal(t, b2.Dirty, false, "b2 Dirty mismatch")
-		assert.Equal(t, b2.USN, 122, "b2 usn mismatch")
+			assert.Equal(t, b1.Label, "js", "b1 label mismatch")
+			assert.Equal(t, b1.Deleted, false, "b1 deleted mismatch")
+			assert.Equal(t, b1.Dirty, false, "b1 Dirty mismatch")
+			assert.Equal(t, b1.USN, 111, "b1 usn mismatch")
 
-		assert.Equal(t, n1.UUID, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", "n1 should have UUID")
-		assert.Equal(t, n1.Body, "", "n1 body mismatch")
-		assert.Equal(t, n1.Deleted, true, "n1 deleted mismatch")
-		assert.Equal(t, n1.Dirty, true, "n1 Dirty mismatch")
-		assert.Equal(t, n1.USN, 11, "n1 usn mismatch")
+			assert.Equal(t, b2.Label, "linux", "b2 label mismatch")
+			assert.Equal(t, b2.Deleted, false, "b2 deleted mismatch")
+			assert.Equal(t, b2.Dirty, false, "b2 Dirty mismatch")
+			assert.Equal(t, b2.USN, 122, "b2 usn mismatch")
 
-		assert.Equal(t, n2.UUID, "43827b9a-c2b0-4c06-a290-97991c896653", "n2 should have UUID")
-		assert.Equal(t, n2.Body, "n2 body", "n2 body mismatch")
-		assert.Equal(t, n2.Deleted, false, "n2 deleted mismatch")
-		assert.Equal(t, n2.Dirty, false, "n2 Dirty mismatch")
-		assert.Equal(t, n2.USN, 12, "n2 usn mismatch")
+			assert.Equal(t, n1.UUID, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", "n1 should have UUID")
+			assert.Equal(t, n1.Body, "", "n1 body mismatch")
+			assert.Equal(t, n1.Deleted, true, "n1 deleted mismatch")
+			assert.Equal(t, n1.Dirty, true, "n1 Dirty mismatch")
+			assert.Equal(t, n1.USN, 11, "n1 usn mismatch")
 
-		assert.Equal(t, n3.UUID, "3e065d55-6d47-42f2-a6bf-f5844130b2d2", "n3 should have UUID")
-		assert.Equal(t, n3.Body, "n3 body", "n3 body mismatch")
-		assert.Equal(t, n3.Deleted, false, "n3 deleted mismatch")
-		assert.Equal(t, n3.Dirty, false, "n3 Dirty mismatch")
-		assert.Equal(t, n3.USN, 13, "n3 usn mismatch")
-	})
+			assert.Equal(t, n2.UUID, "43827b9a-c2b0-4c06-a290-97991c896653", "n2 should have UUID")
+			assert.Equal(t, n2.Body, "n2 body", "n2 body mismatch")
+			assert.Equal(t, n2.Deleted, false, "n2 deleted mismatch")
+			assert.Equal(t, n2.Dirty, false, "n2 Dirty mismatch")
+			assert.Equal(t, n2.USN, 12, "n2 usn mismatch")
 
-	t.Run("--yes flag", func(t *testing.T) {
-		// Setup
-		db := database.InitTestDB(t, fmt.Sprintf("%s/%s", opts.DnoteDir, consts.DnoteDBFileName), nil)
-		testutils.Setup4(t, db)
-
-		// Execute
-		var nid string
-		database.MustScan(t, "getting id of note to remove", db.QueryRow("SELECT rowid FROM notes WHERE uuid = ?", "43827b9a-c2b0-4c06-a290-97991c896653"), &nid)
-
-		testutils.RunDnoteCmd(t, opts, binaryName, "remove", "-y", nid)
-		defer testutils.RemoveDir(t, opts.HomeDir)
-
-		// Test
-		var noteCount, bookCount, jsNoteCount int
-		database.MustScan(t, "counting books", db.QueryRow("SELECT count(*) FROM books"), &bookCount)
-		database.MustScan(t, "counting notes", db.QueryRow("SELECT count(*) FROM notes"), &noteCount)
-		database.MustScan(t, "counting js notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "js-book-uuid"), &jsNoteCount)
-
-		assert.Equalf(t, bookCount, 1, "book count mismatch")
-		assert.Equalf(t, noteCount, 2, "note count mismatch")
-		assert.Equal(t, jsNoteCount, 2, "js book should have 2 notes")
-
-		var b1 database.Book
-		var n1, n2 database.Note
-		database.MustScan(t, "getting b1",
-			db.QueryRow("SELECT label, deleted, usn FROM books WHERE uuid = ?", "js-book-uuid"),
-			&b1.Label, &b1.Deleted, &b1.USN)
-		database.MustScan(t, "getting n1",
-			db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "43827b9a-c2b0-4c06-a290-97991c896653"),
-			&n1.UUID, &n1.Body, &n1.AddedOn, &n1.Deleted, &n1.Dirty, &n1.USN)
-		database.MustScan(t, "getting n2",
-			db.QueryRow("SELECT uuid, body, added_on, deleted, dirty, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f"),
-			&n2.UUID, &n2.Body, &n2.AddedOn, &n2.Deleted, &n2.Dirty, &n2.USN)
-
-		assert.Equal(t, b1.Label, "js", "b1 label mismatch")
-		assert.Equal(t, b1.Deleted, false, "b1 deleted mismatch")
-		assert.Equal(t, b1.Dirty, false, "b1 Dirty mismatch")
-		assert.Equal(t, b1.USN, 111, "b1 usn mismatch")
-
-		assert.Equal(t, n1.UUID, "43827b9a-c2b0-4c06-a290-97991c896653", "n1 should have UUID")
-		assert.Equal(t, n1.Body, "", "n1 body mismatch")
-		assert.Equal(t, n1.Deleted, true, "n1 deleted mismatch")
-		assert.Equal(t, n1.Dirty, true, "n1 Dirty mismatch")
-		assert.Equal(t, n1.USN, 11, "n1 usn mismatch")
-
-		assert.Equal(t, n2.UUID, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", "n2 should have UUID")
-		assert.Equal(t, n2.Body, "Date object implements mathematical comparisons", "n2 body mismatch")
-		assert.Equal(t, n2.Deleted, false, "n2 deleted mismatch")
-		assert.Equal(t, n2.Dirty, false, "n2 Dirty mismatch")
-		assert.Equal(t, n2.USN, 12, "n2 usn mismatch")
-	})
+			assert.Equal(t, n3.UUID, "3e065d55-6d47-42f2-a6bf-f5844130b2d2", "n3 should have UUID")
+			assert.Equal(t, n3.Body, "n3 body", "n3 body mismatch")
+			assert.Equal(t, n3.Deleted, false, "n3 deleted mismatch")
+			assert.Equal(t, n3.Dirty, false, "n3 Dirty mismatch")
+			assert.Equal(t, n3.USN, 13, "n3 usn mismatch")
+		})
+	}
 }
 
 func TestRemoveBook(t *testing.T) {
-	// Setup
-	db := database.InitTestDB(t, fmt.Sprintf("%s/%s", opts.DnoteDir, consts.DnoteDBFileName), nil)
-	testutils.Setup2(t, db)
+	testCases := []struct {
+		yesFlag bool
+	}{
+		{
+			yesFlag: false,
+		},
+		{
+			yesFlag: true,
+		},
+	}
 
-	// Execute
-	testutils.WaitDnoteCmd(t, opts, testutils.UserConfirm, binaryName, "remove", "-b", "js")
-	defer testutils.RemoveDir(t, opts.HomeDir)
+	for _, tc := range testCases {
+		t.Run(fmt.Sprintf("--yes=%t", tc.yesFlag), func(t *testing.T) {
+			// Setup
+			db := database.InitTestDB(t, fmt.Sprintf("%s/%s", opts.DnoteDir, consts.DnoteDBFileName), nil)
+			testutils.Setup2(t, db)
 
-	// Test
-	var noteCount, bookCount, jsNoteCount, linuxNoteCount int
-	database.MustScan(t, "counting books", db.QueryRow("SELECT count(*) FROM books"), &bookCount)
-	database.MustScan(t, "counting notes", db.QueryRow("SELECT count(*) FROM notes"), &noteCount)
-	database.MustScan(t, "counting js notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "js-book-uuid"), &jsNoteCount)
-	database.MustScan(t, "counting linux notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "linux-book-uuid"), &linuxNoteCount)
+			// Execute
+			if tc.yesFlag {
+				testutils.RunDnoteCmd(t, opts, binaryName, "remove", "-y", "js")
+			} else {
+				testutils.WaitDnoteCmd(t, opts, testutils.UserConfirm, binaryName, "remove", "js")
+			}
 
-	assert.Equalf(t, bookCount, 2, "book count mismatch")
-	assert.Equalf(t, noteCount, 3, "note count mismatch")
-	assert.Equal(t, jsNoteCount, 2, "js book should have 2 notes")
-	assert.Equal(t, linuxNoteCount, 1, "linux book book should have 1 note")
+			defer testutils.RemoveDir(t, opts.HomeDir)
 
-	var b1, b2 database.Book
-	var n1, n2, n3 database.Note
-	database.MustScan(t, "getting b1",
-		db.QueryRow("SELECT label, dirty, deleted, usn FROM books WHERE uuid = ?", "js-book-uuid"),
-		&b1.Label, &b1.Dirty, &b1.Deleted, &b1.USN)
-	database.MustScan(t, "getting b2",
-		db.QueryRow("SELECT label, dirty, deleted, usn FROM books WHERE uuid = ?", "linux-book-uuid"),
-		&b2.Label, &b2.Dirty, &b2.Deleted, &b2.USN)
-	database.MustScan(t, "getting n1",
-		db.QueryRow("SELECT uuid, body, added_on, dirty, deleted, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f"),
-		&n1.UUID, &n1.Body, &n1.AddedOn, &n1.Deleted, &n1.Dirty, &n1.USN)
-	database.MustScan(t, "getting n2",
-		db.QueryRow("SELECT uuid, body, added_on, dirty, deleted, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "43827b9a-c2b0-4c06-a290-97991c896653"),
-		&n2.UUID, &n2.Body, &n2.AddedOn, &n2.Deleted, &n2.Dirty, &n2.USN)
-	database.MustScan(t, "getting n3",
-		db.QueryRow("SELECT uuid, body, added_on, dirty, deleted, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "linux-book-uuid", "3e065d55-6d47-42f2-a6bf-f5844130b2d2"),
-		&n3.UUID, &n3.Body, &n3.AddedOn, &n3.Deleted, &n3.Dirty, &n3.USN)
+			// Test
+			var noteCount, bookCount, jsNoteCount, linuxNoteCount int
+			database.MustScan(t, "counting books", db.QueryRow("SELECT count(*) FROM books"), &bookCount)
+			database.MustScan(t, "counting notes", db.QueryRow("SELECT count(*) FROM notes"), &noteCount)
+			database.MustScan(t, "counting js notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "js-book-uuid"), &jsNoteCount)
+			database.MustScan(t, "counting linux notes", db.QueryRow("SELECT count(*) FROM notes WHERE book_uuid = ?", "linux-book-uuid"), &linuxNoteCount)
 
-	assert.NotEqual(t, b1.Label, "js", "b1 label mismatch")
-	assert.Equal(t, b1.Dirty, true, "b1 Dirty mismatch")
-	assert.Equal(t, b1.Deleted, true, "b1 deleted mismatch")
-	assert.Equal(t, b1.USN, 111, "b1 usn mismatch")
+			assert.Equalf(t, bookCount, 2, "book count mismatch")
+			assert.Equalf(t, noteCount, 3, "note count mismatch")
+			assert.Equal(t, jsNoteCount, 2, "js book should have 2 notes")
+			assert.Equal(t, linuxNoteCount, 1, "linux book book should have 1 note")
 
-	assert.Equal(t, b2.Label, "linux", "b2 label mismatch")
-	assert.Equal(t, b2.Dirty, false, "b2 Dirty mismatch")
-	assert.Equal(t, b2.Deleted, false, "b2 deleted mismatch")
-	assert.Equal(t, b2.USN, 122, "b2 usn mismatch")
+			var b1, b2 database.Book
+			var n1, n2, n3 database.Note
+			database.MustScan(t, "getting b1",
+				db.QueryRow("SELECT label, dirty, deleted, usn FROM books WHERE uuid = ?", "js-book-uuid"),
+				&b1.Label, &b1.Dirty, &b1.Deleted, &b1.USN)
+			database.MustScan(t, "getting b2",
+				db.QueryRow("SELECT label, dirty, deleted, usn FROM books WHERE uuid = ?", "linux-book-uuid"),
+				&b2.Label, &b2.Dirty, &b2.Deleted, &b2.USN)
+			database.MustScan(t, "getting n1",
+				db.QueryRow("SELECT uuid, body, added_on, dirty, deleted, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f"),
+				&n1.UUID, &n1.Body, &n1.AddedOn, &n1.Deleted, &n1.Dirty, &n1.USN)
+			database.MustScan(t, "getting n2",
+				db.QueryRow("SELECT uuid, body, added_on, dirty, deleted, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "js-book-uuid", "43827b9a-c2b0-4c06-a290-97991c896653"),
+				&n2.UUID, &n2.Body, &n2.AddedOn, &n2.Deleted, &n2.Dirty, &n2.USN)
+			database.MustScan(t, "getting n3",
+				db.QueryRow("SELECT uuid, body, added_on, dirty, deleted, usn FROM notes WHERE book_uuid = ? AND uuid = ?", "linux-book-uuid", "3e065d55-6d47-42f2-a6bf-f5844130b2d2"),
+				&n3.UUID, &n3.Body, &n3.AddedOn, &n3.Deleted, &n3.Dirty, &n3.USN)
 
-	assert.Equal(t, n1.UUID, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", "n1 should have UUID")
-	assert.Equal(t, n1.Body, "", "n1 body mismatch")
-	assert.Equal(t, n1.Dirty, true, "n1 Dirty mismatch")
-	assert.Equal(t, n1.Deleted, true, "n1 deleted mismatch")
-	assert.Equal(t, n1.USN, 11, "n1 usn mismatch")
+			assert.NotEqual(t, b1.Label, "js", "b1 label mismatch")
+			assert.Equal(t, b1.Dirty, true, "b1 Dirty mismatch")
+			assert.Equal(t, b1.Deleted, true, "b1 deleted mismatch")
+			assert.Equal(t, b1.USN, 111, "b1 usn mismatch")
 
-	assert.Equal(t, n2.UUID, "43827b9a-c2b0-4c06-a290-97991c896653", "n2 should have UUID")
-	assert.Equal(t, n2.Body, "", "n2 body mismatch")
-	assert.Equal(t, n2.Dirty, true, "n2 Dirty mismatch")
-	assert.Equal(t, n2.Deleted, true, "n2 deleted mismatch")
-	assert.Equal(t, n2.USN, 12, "n2 usn mismatch")
+			assert.Equal(t, b2.Label, "linux", "b2 label mismatch")
+			assert.Equal(t, b2.Dirty, false, "b2 Dirty mismatch")
+			assert.Equal(t, b2.Deleted, false, "b2 deleted mismatch")
+			assert.Equal(t, b2.USN, 122, "b2 usn mismatch")
 
-	assert.Equal(t, n3.UUID, "3e065d55-6d47-42f2-a6bf-f5844130b2d2", "n3 should have UUID")
-	assert.Equal(t, n3.Body, "n3 body", "n3 body mismatch")
-	assert.Equal(t, n3.Dirty, false, "n3 Dirty mismatch")
-	assert.Equal(t, n3.Deleted, false, "n3 deleted mismatch")
-	assert.Equal(t, n3.USN, 13, "n3 usn mismatch")
+			assert.Equal(t, n1.UUID, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", "n1 should have UUID")
+			assert.Equal(t, n1.Body, "", "n1 body mismatch")
+			assert.Equal(t, n1.Dirty, true, "n1 Dirty mismatch")
+			assert.Equal(t, n1.Deleted, true, "n1 deleted mismatch")
+			assert.Equal(t, n1.USN, 11, "n1 usn mismatch")
+
+			assert.Equal(t, n2.UUID, "43827b9a-c2b0-4c06-a290-97991c896653", "n2 should have UUID")
+			assert.Equal(t, n2.Body, "", "n2 body mismatch")
+			assert.Equal(t, n2.Dirty, true, "n2 Dirty mismatch")
+			assert.Equal(t, n2.Deleted, true, "n2 deleted mismatch")
+			assert.Equal(t, n2.USN, 12, "n2 usn mismatch")
+
+			assert.Equal(t, n3.UUID, "3e065d55-6d47-42f2-a6bf-f5844130b2d2", "n3 should have UUID")
+			assert.Equal(t, n3.Body, "n3 body", "n3 body mismatch")
+			assert.Equal(t, n3.Dirty, false, "n3 Dirty mismatch")
+			assert.Equal(t, n3.Deleted, false, "n3 deleted mismatch")
+			assert.Equal(t, n3.USN, 13, "n3 usn mismatch")
+		})
+	}
 }

--- a/pkg/cli/testutils/setup.go
+++ b/pkg/cli/testutils/setup.go
@@ -61,10 +61,10 @@ func Setup3(t *testing.T, db *database.DB) {
 func Setup4(t *testing.T, db *database.DB) {
 	b1UUID := "js-book-uuid"
 
-	database.MustExec(t, "setting up book 1", db, "INSERT INTO books (uuid, label) VALUES (?, ?)", b1UUID, "js")
+	database.MustExec(t, "setting up book 1", db, "INSERT INTO books (uuid, label, usn) VALUES (?, ?, ?)", b1UUID, "js", 111)
 
-	database.MustExec(t, "setting up note 1", db, "INSERT INTO notes (rowid, uuid, book_uuid, body, added_on) VALUES (?, ?, ?, ?, ?)", 1, "43827b9a-c2b0-4c06-a290-97991c896653", b1UUID, "Booleans have toString()", 1515199943)
-	database.MustExec(t, "setting up note 2", db, "INSERT INTO notes (rowid, uuid, book_uuid, body, added_on) VALUES (?, ?, ?, ?, ?)", 2, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", b1UUID, "Date object implements mathematical comparisons", 1515199951)
+	database.MustExec(t, "setting up note 1", db, "INSERT INTO notes (rowid, uuid, book_uuid, body, added_on, usn) VALUES (?, ?, ?, ?, ?, ?)", 1, "43827b9a-c2b0-4c06-a290-97991c896653", b1UUID, "Booleans have toString()", 1515199943, 11)
+	database.MustExec(t, "setting up note 2", db, "INSERT INTO notes (rowid, uuid, book_uuid, body, added_on, usn) VALUES (?, ?, ?, ?, ?, ?)", 2, "f0d0fbb7-31ff-45ae-9f0f-4e429c0c797f", b1UUID, "Date object implements mathematical comparisons", 1515199951, 12)
 }
 
 // Setup5 sets up a dnote env #2


### PR DESCRIPTION
Fix #233, #220

```bash
# now deprecated way of removing a book
dnote remote --book js

# new way of removing a book
dnote remove js
# removing note (unchanged)
dnote remove 3
```