### PR TITLE
Improve shell portability

### DIFF
--- a/pkg/cli/scripts/build.sh
+++ b/pkg/cli/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # build.sh compiles dnote binary for target platforms. It is resonsible for creating
 # distributable files that can be released by a human or a script.

--- a/pkg/cli/scripts/dev.sh
+++ b/pkg/cli/scripts/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # dev.sh builds a new binary and replaces the old one in the PATH with it
 set -eux
 

--- a/pkg/cli/scripts/dump_schema.sh
+++ b/pkg/cli/scripts/dump_schema.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # dump_schema.sh dumps the current system's dnote schema
 set -eux
 

--- a/pkg/cli/scripts/test.sh
+++ b/pkg/cli/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # run_server_test.sh runs server test files sequentially
 # https://stackoverflow.com/questions/23715302/go-how-to-run-tests-for-multiple-packages
 

--- a/pkg/server/api/scripts/build.sh
+++ b/pkg/server/api/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux
 
 basePath="$GOPATH/src/github.com/dnote/dnote/pkg/server/api"

--- a/pkg/server/api/scripts/setup.sh
+++ b/pkg/server/api/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # setup.sh installs programs and depedencies necessary to run the project locally
 # usage: ./setup.sh
 set -eux

--- a/pkg/server/api/scripts/test-local.sh
+++ b/pkg/server/api/scripts/test-local.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1090
 # test-local.sh runs api tests using local setting
 set -eux

--- a/pkg/server/api/scripts/test.sh
+++ b/pkg/server/api/scripts/test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # test.sh runs api tests. It is to be invoked by other scripts that set
 # appropriate env vars.
 set -eux

--- a/pkg/server/database/scripts/create-migration.sh
+++ b/pkg/server/database/scripts/create-migration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # create-migration.sh creates a new SQL migration file for the
 # server side Postgres database using the sql-migrate tool.
 set -eux

--- a/pkg/server/database/scripts/install-sql-migrate.sh
+++ b/pkg/server/database/scripts/install-sql-migrate.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 go get -v github.com/rubenv/sql-migrate/...

--- a/pkg/server/scripts/build.sh
+++ b/pkg/server/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux
 
 version=$1

--- a/scripts/license.sh
+++ b/scripts/license.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 function remove_notice {
   sed -i -e '/\/\* Copyright/,/\*\//d' "$1"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # release.sh releases the tarballs and checksum in the build directory
 # to GitHub and brew. A prerequisite is to build those files using build.sh.

--- a/web/scripts/build-prod.sh
+++ b/web/scripts/build-prod.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # build.sh builds a production bundle
 set -eux
 

--- a/web/scripts/build.sh
+++ b/web/scripts/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # build.sh builds a bundle
 set -ex
 

--- a/web/scripts/dev.sh
+++ b/web/scripts/dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # shellcheck disable=SC1090
 # dev.sh builds and starts development environment for standalone app
 set -eux -o pipefail

--- a/web/scripts/setup.sh
+++ b/web/scripts/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # setup.sh prepares the directory structure and copies static files
 set -eux -o pipefail
 

--- a/web/scripts/webpack-dev.sh
+++ b/web/scripts/webpack-dev.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -eux
 
 basePath="$GOPATH/src/github.com/dnote/dnote"


### PR DESCRIPTION
Use `/usr/bin/env` in the Shebang to avoid depending on shell path