### PR TITLE
Allow to build CLI for a specific platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,8 +32,13 @@ You can build either a development version or a production version:
 # Build a development version for your platform and place it in your `PATH`.
 make debug=true build-cli
 
-# Build a production version
+# Build a production version for all platforms
 make version=v0.1.0 build-cli
+
+# Build a production version for a specific platform
+# Note: You cannot cross-compile using this method because Dnote uses CGO
+# and requires the OS specific headers.
+GOOS=[insert OS] GOARCH=[insert arch] make version=v0.1.0 build-cli
 ```
 
 ### Test

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ build-web:
 
 build-server: build-web
 ifndef version
-	$(error version is required. Usage: make version=v0.1.0 build-server)
+	$(error version is required. Usage: make version=0.1.0 build-server)
 endif
 
 	@echo "==> building server"
@@ -93,7 +93,7 @@ ifeq ($(debug), true)
 else
 
 ifndef version
-	$(error version is required. Usage: make version=v0.1.0 build-cli)
+	$(error version is required. Usage: make version=0.1.0 build-cli)
 endif
 
 	@echo "==> building cli"
@@ -104,7 +104,7 @@ endif
 ## release
 release-cli: build-cli
 ifndef version
-	$(error version is required. Usage: make version=v0.1.0 release-cli)
+	$(error version is required. Usage: make version=0.1.0 release-cli)
 endif
 ifndef HUB
 	$(error please install hub)
@@ -128,7 +128,7 @@ endif
 
 release-server: build-server
 ifndef version
-	$(error version is required. Usage: make version=v0.1.0 release-server)
+	$(error version is required. Usage: make version=0.1.0 release-server)
 endif
 ifndef HUB
 	$(error please install hub)


### PR DESCRIPTION
Allow to build CLI for a specific platform

e.g.

```
GOOS=freebsd GOARCH=amd64 make version=0.8.5 build-cli
```