### PR TITLE
Properly embed static files into binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ All notable changes to the projects under this repository will be documented in 
 
 The following log documents the history of the server project.
 
+### 0.3.1 - 2019-11-12
+
+#### Fixed
+
+- Fix static files not being embedded in the binary. (#309)
+- Fix mobile menu not covering the whole screen. (#308)
+
 ### 0.3.0 - 2019-11-12
 
 #### Added

--- a/scripts/server/build.sh
+++ b/scripts/server/build.sh
@@ -29,6 +29,8 @@ build() {
   platform=$1
   arch=$2
 
+  pushd "$basedir"
+
   destDir="$outputDir/$platform-$arch"
   mkdir -p "$destDir"
 
@@ -39,9 +41,11 @@ build() {
   GOARCH="$arch" go build \
     -o "$destDir/dnote-server" \
     -ldflags "-X main.versionTag=$version" \
-    "$projectDir"/pkg/server/*.go
+    "$basedir"/*.go
 
   packr2 clean
+
+  popd
 
   # build tarball
   tarballName="dnote_server_${version}_${platform}_${arch}.tar.gz"
@@ -56,6 +60,7 @@ build() {
   pushd "$outputDir"
   shasum -a 256 "$tarballName" >> "$outputDir/dnote_${version}_checksums.txt"
   popd
+
 }
 
 build linux amd64


### PR DESCRIPTION
Static files were not being embedded to the binary, causing panic on execution.