### PR TITLE
Allow to skip frontmatter when viewing note

### DIFF
--- a/pkg/cli/cmd/cat/cat.go
+++ b/pkg/cli/cmd/cat/cat.go
@@ -55,7 +55,7 @@ func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 		Aliases:    []string{"c"},
 		Short:      "See a note",
 		Example:    example,
-		RunE:       NewRun(ctx),
+		RunE:       NewRun(ctx, false),
 		PreRunE:    preRun,
 		Deprecated: deprecationWarning,
 	}
@@ -64,7 +64,7 @@ func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 }
 
 // NewRun returns a new run function
-func NewRun(ctx context.DnoteCtx) infra.RunEFunc {
+func NewRun(ctx context.DnoteCtx, contentOnly bool) infra.RunEFunc {
 	return func(cmd *cobra.Command, args []string) error {
 		var noteRowIDArg string
 
@@ -87,7 +87,11 @@ func NewRun(ctx context.DnoteCtx) infra.RunEFunc {
 			return err
 		}
 
-		output.NoteInfo(info)
+		if contentOnly {
+			output.NoteContent(info)
+		} else {
+			output.NoteInfo(info)
+		}
 
 		return nil
 	}

--- a/pkg/cli/cmd/view/view.go
+++ b/pkg/cli/cmd/view/view.go
@@ -41,6 +41,7 @@ var example = `
  `
 
 var nameOnly bool
+var contentOnly bool
 
 func preRun(cmd *cobra.Command, args []string) error {
 	if len(args) > 2 {
@@ -63,6 +64,7 @@ func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 
 	f := cmd.Flags()
 	f.BoolVarP(&nameOnly, "name-only", "", false, "print book names only")
+	f.BoolVarP(&contentOnly, "content-only", "", false, "print the note content only")
 
 	return cmd
 }
@@ -79,13 +81,13 @@ func newRun(ctx context.DnoteCtx) infra.RunEFunc {
 			}
 
 			if utils.IsNumber(args[0]) {
-				run = cat.NewRun(ctx)
+				run = cat.NewRun(ctx, contentOnly)
 			} else {
 				run = ls.NewRun(ctx, false)
 			}
 		} else if len(args) == 2 {
 			// DEPRECATED: passing book name to view command is deprecated
-			run = cat.NewRun(ctx)
+			run = cat.NewRun(ctx, false)
 		} else {
 			return errors.New("Incorrect number of arguments")
 		}

--- a/pkg/cli/output/output.go
+++ b/pkg/cli/output/output.go
@@ -43,6 +43,10 @@ func NoteInfo(info database.NoteInfo) {
 	fmt.Printf("\n-------------------------------------------------------\n")
 }
 
+func NoteContent(info database.NoteInfo) {
+	fmt.Printf("%s", info.Content)
+}
+
 // BookInfo prints a note information
 func BookInfo(info database.BookInfo) {
 	log.Infof("book name: %s\n", info.Name)


### PR DESCRIPTION
Add `--content-only` flag to `dnote view` command to skip printing the frontmatter.

Please see https://github.com/dnote/dnote/issues/483#issuecomment-645213139