### PR TITLE
Fix build annotation

### DIFF
--- a/pkg/cli/dirs/dirs_unix.go
+++ b/pkg/cli/dirs/dirs_unix.go
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with Dnote.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 // +build linux darwin
 
 package dirs

--- a/pkg/cli/dirs/dirs_unix_test.go
+++ b/pkg/cli/dirs/dirs_unix_test.go
@@ -15,7 +15,6 @@
  * You should have received a copy of the GNU General Public License
  * along with Dnote.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 // +build linux darwin
 
 package dirs


### PR DESCRIPTION
```
make test-cli
...
# github.com/dnote/dnote/pkg/cli/dirs
dirs/dirs_unix.go:19:1: +build comment must appear before package clause and be followed by a blank line
dirs/dirs_unix_test.go:19:1: +build comment must appear before package clause and be followed by a blank line
```