### PR TITLE
Stdin

### DIFF
--- a/pkg/cli/cmd/add/add.go
+++ b/pkg/cli/cmd/add/add.go
@@ -21,6 +21,7 @@ package add
 import (
 	"database/sql"
 	"time"
+	"os"
 
 	"github.com/dnote/dnote/pkg/cli/context"
 	"github.com/dnote/dnote/pkg/cli/database"
@@ -72,6 +73,16 @@ func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 func getContent(ctx context.DnoteCtx) (string, error) {
 	if contentFlag != "" {
 		return contentFlag, nil
+	}
+
+	// check for piped content
+	fInfo, _ := os.Stdin.Stat()
+    if fInfo.Mode() & os.ModeCharDevice == 0 {
+		c, err := ui.ReadStdInput()
+		if err != nil {
+			return "", errors.Wrap(err, "Failed to get piped input")
+		}
+		return c, nil
 	}
 
 	fpath, err := ui.GetTmpContentPath(ctx)

--- a/pkg/cli/cmd/add/add.go
+++ b/pkg/cli/cmd/add/add.go
@@ -77,7 +77,7 @@ func getContent(ctx context.DnoteCtx) (string, error) {
 
 	// check for piped content
 	fInfo, _ := os.Stdin.Stat()
-    if fInfo.Mode() & os.ModeCharDevice == 0 {
+	if fInfo.Mode() & os.ModeCharDevice == 0 {
 		c, err := ui.ReadStdInput()
 		if err != nil {
 			return "", errors.Wrap(err, "Failed to get piped input")

--- a/pkg/cli/ui/terminal.go
+++ b/pkg/cli/ui/terminal.go
@@ -95,3 +95,19 @@ func Confirm(question string, optimistic bool) (bool, error) {
 
 	return confirmed, nil
 }
+
+// Grab text from stdin content
+func ReadStdInput() (string, error) {
+	var lines []string
+
+	s := bufio.NewScanner(os.Stdin)
+	for s.Scan() {
+		lines = append(lines, s.Text())
+	}
+	err := s.Err()
+	if err != nil {
+		return "", errors.Wrap(err, "reading pipe")
+	}
+
+	return strings.Join(lines, "\n"), nil
+}


### PR DESCRIPTION
## Short description

This adds the ability to create a new note via the contents of stdin. Having this enables actions like:
```
echo "a new fact" | dnote add myfacts
# or
cat /proc/cpuinfo | dnote add mycomputer
# or
dnote add mythoughts << EOF
I like learning
new things
EOF
```

This also resolves https://github.com/dnote/dnote/issues/581 and potentially https://github.com/dnote/dnote/issues/82 as well