### PR TITLE
add ability to list note timestamps

### DIFF
--- a/pkg/cli/cmd/ls/ls.go
+++ b/pkg/cli/cmd/ls/ls.go
@@ -22,6 +22,7 @@ import (
 	"database/sql"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/dnote/dnote/pkg/cli/context"
 	"github.com/dnote/dnote/pkg/cli/infra"
@@ -58,7 +59,7 @@ func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 		Aliases:    []string{"l", "notes"},
 		Short:      "List all notes",
 		Example:    example,
-		RunE:       NewRun(ctx, false),
+		RunE:       NewRun(ctx, false, false),
 		PreRunE:    preRun,
 		Deprecated: deprecationWarning,
 	}
@@ -67,7 +68,7 @@ func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 }
 
 // NewRun returns a new run function for ls
-func NewRun(ctx context.DnoteCtx, nameOnly bool) infra.RunEFunc {
+func NewRun(ctx context.DnoteCtx, nameOnly bool, timestamps bool) infra.RunEFunc {
 	return func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {
 			if err := printBooks(ctx, nameOnly); err != nil {
@@ -78,7 +79,7 @@ func NewRun(ctx context.DnoteCtx, nameOnly bool) infra.RunEFunc {
 		}
 
 		bookName := args[0]
-		if err := printNotes(ctx, bookName); err != nil {
+		if err := printNotes(ctx, bookName, timestamps); err != nil {
 			return errors.Wrapf(err, "viewing book '%s'", bookName)
 		}
 
@@ -95,6 +96,7 @@ type bookInfo struct {
 // noteInfo is an information about the note to be printed on screen
 type noteInfo struct {
 	RowID int
+	AddedOn int64
 	Body  string
 }
 
@@ -166,7 +168,7 @@ func printBooks(ctx context.DnoteCtx, nameOnly bool) error {
 	return nil
 }
 
-func printNotes(ctx context.DnoteCtx, bookName string) error {
+func printNotes(ctx context.DnoteCtx, bookName string, timestamps bool) error {
 	db := ctx.DB
 
 	var bookUUID string
@@ -177,7 +179,7 @@ func printNotes(ctx context.DnoteCtx, bookName string) error {
 		return errors.Wrap(err, "querying the book")
 	}
 
-	rows, err := db.Query(`SELECT rowid, body FROM notes WHERE book_uuid = ? AND deleted = ? ORDER BY added_on ASC;`, bookUUID, false)
+	rows, err := db.Query(`SELECT rowid, added_on, body FROM notes WHERE book_uuid = ? AND deleted = ? ORDER BY added_on ASC;`, bookUUID, false)
 	if err != nil {
 		return errors.Wrap(err, "querying notes")
 	}
@@ -186,7 +188,7 @@ func printNotes(ctx context.DnoteCtx, bookName string) error {
 	infos := []noteInfo{}
 	for rows.Next() {
 		var info noteInfo
-		err = rows.Scan(&info.RowID, &info.Body)
+		err = rows.Scan(&info.RowID, &info.AddedOn, &info.Body)
 		if err != nil {
 			return errors.Wrap(err, "scanning a row")
 		}
@@ -199,12 +201,16 @@ func printNotes(ctx context.DnoteCtx, bookName string) error {
 	for _, info := range infos {
 		body, isExcerpt := formatBody(info.Body)
 
-		rowid := log.ColorYellow.Sprintf("(%d)", info.RowID)
+		preface := log.ColorYellow.Sprintf("(%d)", info.RowID)
+		if timestamps {
+			local_time := time.Unix(0, info.AddedOn).Format(time.DateTime)
+			preface = log.ColorYellow.Sprintf("(%s)", local_time)
+		}
 		if isExcerpt {
 			body = fmt.Sprintf("%s %s", body, log.ColorYellow.Sprintf("[---More---]"))
 		}
 
-		log.Plainf("%s %s\n", rowid, body)
+		log.Plainf("%s %s\n", preface, body)
 	}
 
 	return nil

--- a/pkg/cli/cmd/view/view.go
+++ b/pkg/cli/cmd/view/view.go
@@ -42,6 +42,7 @@ var example = `
 
 var nameOnly bool
 var contentOnly bool
+var timestamps bool
 
 func preRun(cmd *cobra.Command, args []string) error {
 	if len(args) > 2 {
@@ -65,6 +66,7 @@ func NewCmd(ctx context.DnoteCtx) *cobra.Command {
 	f := cmd.Flags()
 	f.BoolVarP(&nameOnly, "name-only", "", false, "print book names only")
 	f.BoolVarP(&contentOnly, "content-only", "", false, "print the note content only")
+	f.BoolVarP(&timestamps, "timestamps", "t", false, "print creation timestamp of notes rather than IDs")
 
 	return cmd
 }
@@ -74,7 +76,11 @@ func newRun(ctx context.DnoteCtx) infra.RunEFunc {
 		var run infra.RunEFunc
 
 		if len(args) == 0 {
-			run = ls.NewRun(ctx, nameOnly)
+			if timestamps {
+				return errors.New("timestamps flag is only valid when viewing notes")
+			}
+
+			run = ls.NewRun(ctx, nameOnly, false)
 		} else if len(args) == 1 {
 			if nameOnly {
 				return errors.New("--name-only flag is only valid when viewing books")
@@ -83,7 +89,7 @@ func newRun(ctx context.DnoteCtx) infra.RunEFunc {
 			if utils.IsNumber(args[0]) {
 				run = cat.NewRun(ctx, contentOnly)
 			} else {
-				run = ls.NewRun(ctx, false)
+				run = ls.NewRun(ctx, false, timestamps)
 			}
 		} else if len(args) == 2 {
 			// DEPRECATED: passing book name to view command is deprecated


### PR DESCRIPTION
## Overview
This PR addresses https://github.com/dnote/dnote/issues/90 by adding a flag to the `view` subcommand that lists the note's creation timestamps rather than the note IDs. I know that PR is pretty old at this point but it seemed like a neat feature and simple enough to implement. Even so, I don't mind if you don't want to merge this.



## Show and tell
Output of `dnote view --help` for reference

```
List books, notes or view a content

Usage:
  dnote view <book name?> <note index?> [flags]

<truncated for brevity>

Flags:
      --content-only   print the note content only
  -h, --help           help for view
      --name-only      print book names only
  -t, --timestamps     print creation timestamp of notes rather than IDs
```

The resulting output would look like the below.
```
# dnote a Logbook -c "I edited a file"
# dnote a Logbook -c "I saved the file"
# dnote a Logbook -c "I phoned a friend"
# dnote view Logbook --timestamps
  • on book Logbook
  (2023-02-21 21:31:16) I edited a file
  (2023-02-21 21:31:30) I saved the file
  (2023-02-21 21:31:42) I phoned a friend
```