### PR TITLE
Increase the upgrade check interval to 8 weeks

### DIFF
--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -32,8 +32,8 @@ import (
 	"github.com/pkg/errors"
 )
 
-// upgradeInterval is 3 weeks
-var upgradeInterval int64 = 86400 * 7 * 3
+// upgradeInterval is 8 weeks
+var upgradeInterval int64 = 86400 * 7 * 8
 
 // shouldCheckUpdate checks if update should be checked
 func shouldCheckUpdate(ctx context.DnoteCtx) (bool, error) {


### PR DESCRIPTION
Dnote CLI has been stable and seldom updated. Therefore, it is rather distracting for no reason to check for new version every 3 weeks.