### PR TITLE
Fix missing assets in a server release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ ifndef version
 	$(error version is required. Usage: make version=0.1.0 build-server)
 endif
 
+	@echo "==> building server assets"
+	@(cd "${currentDir}/pkg/server/assets/" && ./styles/build.sh)
+	@(cd "${currentDir}/pkg/server/assets/" && ./js/build.sh)
+
 	@echo "==> building server"
 	@${currentDir}/scripts/server/build.sh $(version)
 .PHONY: build-server

--- a/host/docker/Dockerfile
+++ b/host/docker/Dockerfile
@@ -5,7 +5,8 @@ RUN test -n "$tarballName"
 
 # add dependency to execute a golang binary with dynamical linking.
 RUN apk add --no-cache \
-        libc6-compat
+        libc6-compat \
+        gcompat
 
 WORKDIR dnote
 


### PR DESCRIPTION
Fix missing assets in server v2.1.0.

Dnote server is run inside Docker container using Alpine was intermittently getting `__fprintf_chk: symbol not found`. Fixed by adding a library.