### PR TITLE
Disable completion command

### DIFF
--- a/pkg/cli/cmd/root/root.go
+++ b/pkg/cli/cmd/root/root.go
@@ -27,6 +27,9 @@ var root = &cobra.Command{
 	Short:         "Dnote - a simple command line notebook",
 	SilenceErrors: true,
 	SilenceUsage:  true,
+	CompletionOptions: cobra.CompletionOptions{
+		DisableDefaultCmd: true,
+	},
 }
 
 // Register adds a new command


### PR DESCRIPTION
A newer version of cobra automatically inserted a "completion" subcommand to dnote. This goes against the project tenet of simplicity. Remove the subcommand.