### PR TITLE
Allow to download darwin/arm64 using the installation script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -87,6 +87,7 @@ check_platform() {
   found=1
   case "$platform" in
     darwin/amd64) found=0;;
+    darwin/arm64) found=0;;
     linux/amd64) found=0 ;;
     linux/arm64) found=0 ;;
   esac


### PR DESCRIPTION
#623 suggests that darwin/arm64 binary works. Therefore, allow it to be downloaded