### PR TITLE
Allow to disable automatic upgrade check in CLI

### DIFF
--- a/pkg/cli/config/config.go
+++ b/pkg/cli/config/config.go
@@ -32,8 +32,9 @@ import (
 
 // Config holds dnote configuration
 type Config struct {
-	Editor      string `yaml:"editor"`
-	APIEndpoint string `yaml:"apiEndpoint"`
+	Editor             string `yaml:"editor"`
+	APIEndpoint        string `yaml:"apiEndpoint"`
+	EnableUpgradeCheck bool   `yaml:"enableUpgradeCheck"`
 }
 
 func checkLegacyPath(ctx context.DnoteCtx) (string, bool) {

--- a/pkg/cli/context/ctx.go
+++ b/pkg/cli/context/ctx.go
@@ -35,14 +35,15 @@ type Paths struct {
 
 // DnoteCtx is a context holding the information of the current runtime
 type DnoteCtx struct {
-	Paths            Paths
-	APIEndpoint      string
-	Version          string
-	DB               *database.DB
-	SessionKey       string
-	SessionKeyExpiry int64
-	Editor           string
-	Clock            clock.Clock
+	Paths              Paths
+	APIEndpoint        string
+	Version            string
+	DB                 *database.DB
+	SessionKey         string
+	SessionKeyExpiry   int64
+	Editor             string
+	Clock              clock.Clock
+	EnableUpgradeCheck bool
 }
 
 // Redact replaces private information from the context with a set of

--- a/pkg/cli/infra/init.go
+++ b/pkg/cli/infra/init.go
@@ -150,14 +150,15 @@ func SetupCtx(ctx context.DnoteCtx) (context.DnoteCtx, error) {
 	}
 
 	ret := context.DnoteCtx{
-		Paths:            ctx.Paths,
-		Version:          ctx.Version,
-		DB:               ctx.DB,
-		SessionKey:       sessionKey,
-		SessionKeyExpiry: sessionKeyExpiry,
-		APIEndpoint:      cf.APIEndpoint,
-		Editor:           cf.Editor,
-		Clock:            clock.New(),
+		Paths:              ctx.Paths,
+		Version:            ctx.Version,
+		DB:                 ctx.DB,
+		SessionKey:         sessionKey,
+		SessionKeyExpiry:   sessionKeyExpiry,
+		APIEndpoint:        cf.APIEndpoint,
+		Editor:             cf.Editor,
+		Clock:              clock.New(),
+		EnableUpgradeCheck: cf.EnableUpgradeCheck,
 	}
 
 	return ret, nil
@@ -354,8 +355,9 @@ func initConfigFile(ctx context.DnoteCtx, apiEndpoint string) error {
 	editor := getEditorCommand()
 
 	cf := config.Config{
-		Editor:      editor,
-		APIEndpoint: apiEndpoint,
+		Editor:             editor,
+		APIEndpoint:        apiEndpoint,
+		EnableUpgradeCheck: true,
 	}
 
 	if err := config.Write(ctx, cf); err != nil {

--- a/pkg/cli/migrate/migrate.go
+++ b/pkg/cli/migrate/migrate.go
@@ -20,6 +20,7 @@ package migrate
 
 import (
 	"database/sql"
+
 	"github.com/dnote/dnote/pkg/cli/consts"
 	"github.com/dnote/dnote/pkg/cli/context"
 	"github.com/dnote/dnote/pkg/cli/log"
@@ -47,6 +48,7 @@ var LocalSequence = []migration{
 	lm10,
 	lm11,
 	lm12,
+	lm13,
 }
 
 // RemoteSequence is a list of remote migrations to be run

--- a/pkg/cli/migrate/migrations.go
+++ b/pkg/cli/migrate/migrations.go
@@ -550,6 +550,25 @@ var lm12 = migration{
 	},
 }
 
+var lm13 = migration{
+	name: "add enableUpgradeCheck to the configuration file",
+	run: func(ctx context.DnoteCtx, tx *database.DB) error {
+		cf, err := config.Read(ctx)
+		if err != nil {
+			return errors.Wrap(err, "reading config")
+		}
+
+		cf.EnableUpgradeCheck = true
+
+		err = config.Write(ctx, cf)
+		if err != nil {
+			return errors.Wrap(err, "writing config")
+		}
+
+		return nil
+	},
+}
+
 var rm1 = migration{
 	name: "sync-book-uuids-from-server",
 	run: func(ctx context.DnoteCtx, tx *database.DB) error {

--- a/pkg/cli/upgrade/upgrade.go
+++ b/pkg/cli/upgrade/upgrade.go
@@ -112,6 +112,11 @@ func checkVersion(ctx context.DnoteCtx) error {
 
 // Check triggers update if needed
 func Check(ctx context.DnoteCtx) error {
+	// If upgrade check is not enabled, do not proceed further
+	if !ctx.EnableUpgradeCheck {
+		return nil
+	}
+
 	shouldCheck, err := shouldCheckUpdate(ctx)
 	if err != nil {
 		return errors.Wrap(err, "checking if dnote should check update")


### PR DESCRIPTION
Implements #632 

* Add a new key `enableUpgradeCheck` in the config. It is a boolean with a default value of `true`.
* Add a migration to add the key to the existing configuration files.